### PR TITLE
🐛 Do not panic if service account opts error out.

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -70,10 +70,13 @@ func WithAPIToken(token string) ClientOption {
 	return withTokenSource{"", src, nil}
 }
 
-// WithServiceAccount returns a ClientOption that specifies the credentials file to use.
+// WithServiceAccount returns a ClientOption that specifies the credentials to use.
 func WithServiceAccount(data []byte) ClientOption {
 	ts, sa, err := signer.NewServiceAccountTokenSource(data)
-	return withTokenSource{sa.ApiEndpoint, ts, err}
+	if err != nil {
+		return withTokenSource{"", nil, err}
+	}
+	return withTokenSource{sa.ApiEndpoint, ts, nil}
 }
 
 // WithServiceAccountFile returns a ClientOption that specifies the credentials file to use.
@@ -82,9 +85,7 @@ func WithServiceAccountFile(filename string) ClientOption {
 	if err != nil {
 		return withTokenSource{"", nil, err}
 	}
-
-	ts, sa, err := signer.NewServiceAccountTokenSource(data)
-	return withTokenSource{sa.ApiEndpoint, ts, err}
+	return WithServiceAccount(data)
 }
 
 // WithoutAuthentication returns a ClientOption that disables authentication.


### PR DESCRIPTION
If the `NewServiceAccountTokenSource` errs out, we get a nil `sa` back. Trying to access `sa.ApiEndpoint` causes a panic. Reuse `WithServiceAccount` when calling `WithServiceAccountFile` since the only diff is we need to read the file first in the latter.