### PR TITLE
✨ make MONDOO_API_TOKEN optional

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -27,20 +27,16 @@ import (
 func main() {
 	flag.Parse()
 
-	token, ok := os.LookupEnv("MONDOO_API_TOKEN")
-	if !ok {
-		log.Fatalln(fmt.Errorf("MONDOO_API_TOKEN environment variable not set"))
-	}
-	err := generateSchema(token, ".")
+	err := generateSchema(".")
 	if err != nil {
 		log.Fatalln(err)
 	}
 }
 
 // generateSchema generates the mondoogql package in basePath.
-func generateSchema(token string, basePath string) error {
+func generateSchema(basePath string) error {
 	// fetch the graphql schema
-	schema, err := loadSchema(token)
+	schema, err := loadSchema()
 	if err != nil {
 		return err
 	}
@@ -74,7 +70,7 @@ func generateSchema(token string, basePath string) error {
 }
 
 // loadSchema loads the GraphQL schema from the Mondoo API.
-func loadSchema(token string) (schema interface{}, err error) {
+func loadSchema() (schema interface{}, err error) {
 	introspection := `
 {
   __schema {
@@ -189,7 +185,12 @@ fragment TypeRef on __Type {
 	}
 
 	// set headers
-	req.Header.Set("Authorization", "bearer "+token)
+	token, ok := os.LookupEnv("MONDOO_API_TOKEN")
+	if ok {
+		req.Header.Set("Authorization", "bearer "+token)
+	} else {
+		log.Println("MONDOO_API_TOKEN environment variable not set")
+	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Host", apiHost)


### PR DESCRIPTION
If the API token is not set, we get this error:
```
$ make generate
echo "Ensure the MONDOO_API_TOKEN environment variable is set."
Ensure the MONDOO_API_TOKEN environment variable is set.
```
And when set to something, we get this:
```
make generate
echo "Generating code..."
Generating code...
go generate ./...
using endpoint http://127.0.0.1:8989/query
2024/10/18 16:55:10 non-200 OK status code: 401 Unauthorized body: "{\"code\":16,\"message\":\"request permission unauthenticated\"}"
exit status 1
mondoogql.go:4: running "go": exit status 1
make: *** [generate] Error 1
```
This code avoids setting the auth header when the API token is not needed.